### PR TITLE
MOBC以外にも対応

### DIFF
--- a/isslwings/operation.py
+++ b/isslwings/operation.py
@@ -13,6 +13,16 @@ if os.environ.get("USES_DOCKER") != None:
 else:
     default_url = "https://localhost:5001"
 
+default_obc_info = {
+    "name": "MOBC",
+    "hk_tlm_info": {
+        "tlm_name": "HK",
+        "cmd_counter": "OBC_GS_CMD_COUNTER",
+        "cmd_last_exec_id": "OBC_GS_CMD_LAST_EXEC_ID",
+        "cmd_last_exec_sts": "OBC_GS_CMD_LAST_EXEC_STS"
+    }
+}
+
 default_authentication_info = {
     "client_id": "hoge_id",
     "client_secret": "hoge_secret",
@@ -21,11 +31,17 @@ default_authentication_info = {
     "password": "piyopiyo"
 }
 
-
 class Operation:
-    def __init__(self, url: str = default_url, auto_connect: bool = True, authentication_info: dict = default_authentication_info) -> None:
+    def __init__(
+        self,
+        url: str = default_url,
+        auto_connect: bool = True,
+        obc_info: dict = default_obc_info,
+        authentication_info: dict = default_authentication_info
+    ) -> None:
         self.url = url
         self.operation_id = ""
+        self.obc_info = obc_info
         self.authorized_headers = {} # 認証が必要
 
         # 認証を入れていく
@@ -188,19 +204,25 @@ class Operation:
 
         return telemetry_data, received_time
 
-    def send_rt_cmd(self, cmd_code: int, cmd_params_value: tuple) -> None:
-        command_to_send = self._generate_cmd_dict(cmd_code, cmd_params_value)
+    def send_rt_cmd(self, cmd_code: int, cmd_params_value: tuple, component: str = "") -> None:
+        command_to_send = self._generate_cmd_dict(cmd_code, cmd_params_value, component)
         self._send_rt_cmd(command_to_send)
 
         time.sleep(0.1)
 
-    def send_bl_cmd(self, ti: int, cmd_code: int, cmd_params_value: tuple) -> None:
-        command_to_send = self._generate_cmd_dict(cmd_code, cmd_params_value)
+    def send_bl_cmd(self, ti: int, cmd_code: int, cmd_params_value: tuple, component: str = "") -> None:
+        command_to_send = self._generate_cmd_dict(cmd_code, cmd_params_value, component)
         self._send_bl_cmd(ti, command_to_send)
 
         time.sleep(0.1)
 
-    def _generate_cmd_dict(self, cmd_code: int, cmd_params_value: tuple) -> dict:
+    def get_obc_info(self) -> dict:
+        return self.obc_info
+
+    def _generate_cmd_dict(self, cmd_code: int, cmd_params_value: tuple, component: str = "") -> dict:
+        if component == "":
+            component = self.obc_info["name"]
+
         response = self.client.get(
             "{}/api/operations/{}/cmd".format(self.url, self.operation_id),
             headers=self.authorized_headers
@@ -212,7 +234,7 @@ class Operation:
         # 該当するcmd_codeのコマンド情報を探す
         command_is_found = False
         for command in response["data"]:
-            if int(command["code"], base=16) == cmd_code:
+            if command["component"] == component and int(command["code"], base=16) == cmd_code:
                 command_is_found = True
                 break
 
@@ -232,7 +254,6 @@ class Operation:
         return command_to_send
 
     def _send_rt_cmd(self, command: dict) -> None:
-
         command["execType"] = "RT"
         response = self.client.post(
             "{}/api/operations/{}/cmd".format(self.url, self.operation_id),
@@ -244,7 +265,6 @@ class Operation:
             raise Exception('send_cmd failed.\n" + "command "{}"'.format(command))
 
     def _send_bl_cmd(self, ti: int, command: dict) -> None:
-
         command["execType"] = "BL"
         command["execTime"] = ti
         response = self.client.post(

--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -23,6 +23,7 @@ def generate_and_receive_tlm(
     raise Exception("No response to GENERATE_TLM.")
 
 
+# FIXME: MOBC経由からの2nd OBCへのコマンドは，GS counterで confirm できないので，一旦対応しない．別関数つくる？
 def send_rt_cmd_and_confirm(
     ope: Operation, cmd_code: int, cmd_args: tuple, tlm_code_hk: int
 ) -> str:
@@ -34,6 +35,7 @@ def send_rt_cmd_and_confirm(
     return _send_cmd_and_confirm(ope, func_send_cmd, cmd_code, cmd_args, tlm_code_hk)
 
 
+# FIXME: MOBC経由からの2nd OBCへのコマンドは，GS counterで confirm できないので，一旦対応しない．別関数つくる？
 def send_bl_cmd_and_confirm(
     ope: Operation, ti: int, cmd_code: int, cmd_args: tuple, tlm_code_hk: int
 ) -> str:
@@ -53,7 +55,7 @@ def _send_cmd_and_confirm(
     tlm_code_hk: int,
 ) -> str:
     tlm_HK, _ = ope.get_latest_tlm(tlm_code_hk)
-    command_count_before = tlm_HK["HK.OBC_GS_CMD_COUNTER"]
+    command_count_before = tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_counter"]]
 
     func_send_cmd(cmd_code, cmd_args)
 
@@ -61,11 +63,11 @@ def _send_cmd_and_confirm(
         time.sleep(0.2)
 
         tlm_HK, _ = ope.get_latest_tlm(tlm_code_hk)
-        command_count_after = tlm_HK["HK.OBC_GS_CMD_COUNTER"]
-        command_exec_id = tlm_HK["HK.OBC_GS_CMD_LAST_EXEC_ID"]
+        command_count_after = tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_counter"]]
+        command_exec_id = tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_last_exec_id"]]
 
         if command_count_after > command_count_before and command_exec_id == cmd_code:
-            return tlm_HK["HK.OBC_GS_CMD_LAST_EXEC_STS"]
+            return tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_last_exec_sts"]]
 
     raise Exception("No response to command code:" + str(cmd_code) + ".")
 

--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -54,8 +54,10 @@ def _send_cmd_and_confirm(
     cmd_args: tuple,
     tlm_code_hk: int,
 ) -> str:
+    hk_tlm_info = ope.get_obc_info()["hk_tlm_info"]
+    hk_tlm_name = hk_tlm_info["tlm_name"]
     tlm_HK, _ = ope.get_latest_tlm(tlm_code_hk)
-    command_count_before = tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_counter"]]
+    command_count_before = tlm_HK[hk_tlm_name + "." + hk_tlm_info["cmd_counter"]]
 
     func_send_cmd(cmd_code, cmd_args)
 
@@ -63,11 +65,11 @@ def _send_cmd_and_confirm(
         time.sleep(0.2)
 
         tlm_HK, _ = ope.get_latest_tlm(tlm_code_hk)
-        command_count_after = tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_counter"]]
-        command_exec_id = tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_last_exec_id"]]
+        command_count_after = tlm_HK[hk_tlm_name + "." + hk_tlm_info["cmd_counter"]]
+        command_exec_id = tlm_HK[hk_tlm_name + "." + hk_tlm_info["cmd_last_exec_id"]]
 
         if command_count_after > command_count_before and command_exec_id == cmd_code:
-            return tlm_HK[ope.get_obc_info()["hk_tlm_info"]["tlm_name"] + "." + ope.get_obc_info()["hk_tlm_info"]["cmd_last_exec_sts"]]
+            return tlm_HK[hk_tlm_name + "." + hk_tlm_info["cmd_last_exec_sts"]]
 
     raise Exception("No response to command code:" + str(cmd_code) + ".")
 


### PR DESCRIPTION
## 概要
MOBC以外にも対応

## Issue
- https://github.com/ut-issl/python-wings-interface/issues/2

## 詳細
- MOBC以外のOBCにも対応
  - 具体的には，HKテレメやcmd counterの名前をユーザー定義に
  - 複数のOBCにcmdを送信できる環境で，所望のOBCに対してCmdを打てるように

以下は未対応
- MOBC経由で2nd OBCへのコマンドをうって，それをconfirmする，つまり `send_rt_cmd_and_confirm` , `send_cl_cmd_and_confirm` は未対応（2nd OBCに打てない）．
  - これは，MOBCのgs cmd counterには2nd OBCへのコマンドは含まれないからである．
  - ただし，これを今後作りやすいように，以下のような修正を入れている
    - https://github.com/ut-issl/python-wings-interface/blob/7a3f83fb48757daa4b4f6cd9614e2fd2952babe7/isslwings/operation.py#L222-L224 

## 検証結果
MOBC側はSILSで検証．AOBC側をaocsに試してもらう．

## 影響範囲
デフォルト値をMOBCとして設定しているので，後方互換性はある．