### PR TITLE
HEXテレメをintにしたりされなかったりする挙動を修正

### DIFF
--- a/isslwings/operation.py
+++ b/isslwings/operation.py
@@ -167,17 +167,21 @@ class Operation:
             # TODO: テレメデータがない時の例外処理を加える
 
             # strで読み込んでしまっているので、適切な型へcastする
-            # int -> float の順で変換に失敗したらstrで読む
-            try:
-                data = int(telemetry["telemetryValue"]["value"])
-            except:
+            # hexはそのまま
+            # その他は int -> float の順で変換に失敗したらstrで読む
+            if telemetry["telemetryInfo"]["convType"] == "HEX":
+                data = telemetry["telemetryValue"]["value"]
+            else:
                 try:
-                    data = int(telemetry["telemetryValue"]["value"], base=16)
+                    data = int(telemetry["telemetryValue"]["value"])
                 except:
                     try:
-                        data = float(telemetry["telemetryValue"]["value"])
+                        data = int(telemetry["telemetryValue"]["value"], base=16)
                     except:
-                        data = telemetry["telemetryValue"]["value"]
+                        try:
+                            data = float(telemetry["telemetryValue"]["value"])
+                        except:
+                            data = telemetry["telemetryValue"]["value"]
 
             telemetry_data[telemetry["telemetryInfo"]["name"]] = data
 


### PR DESCRIPTION
## 概要
HEXテレメをintにしたりされなかったりする挙動を修正

## Issue
NA

## 詳細
WINGSから文字列で降ってくるテレメを，現在は intでパースして，OKならint，できなければfloat，それでもだめならstringにしてる．

HEXで，a-fがあるなしで型がかわって困ったので，HEXはそのまま返すようにした．


