### PR TITLE
tl_cmdとutl_cmdも打てるようにする

### DIFF
--- a/isslwings/operation.py
+++ b/isslwings/operation.py
@@ -220,6 +220,18 @@ class Operation:
 
         time.sleep(0.1)
 
+    def send_tl_cmd(self, ti: int, cmd_code: int, cmd_params_value: tuple, component: str = "") -> None:
+        command_to_send = self._generate_cmd_dict(cmd_code, cmd_params_value, component)
+        self._send_tl_cmd(ti, command_to_send)
+
+        time.sleep(0.1)
+
+    def send_utl_cmd(self, unixtime: float, cmd_code: int, cmd_params_value: tuple, component: str = "") -> None:
+        command_to_send = self._generate_cmd_dict(cmd_code, cmd_params_value, component)
+        self._send_utl_cmd(unixtime, command_to_send)
+
+        time.sleep(0.1)
+
     def get_obc_info(self) -> dict:
         return self.obc_info
 
@@ -271,6 +283,30 @@ class Operation:
     def _send_bl_cmd(self, ti: int, command: dict) -> None:
         command["execType"] = "BL"
         command["execTime"] = ti
+        response = self.client.post(
+            "{}/api/operations/{}/cmd".format(self.url, self.operation_id),
+            json={"command": command},
+            headers=self.authorized_headers
+        ).json()
+
+        if response["ack"] == False:
+            raise Exception('send_cmd failed.\n" + "command "{}"'.format(command))
+
+    def _send_tl_cmd(self, ti: int, command: dict) -> None:
+        command["execType"] = "TL"
+        command["execTime"] = ti
+        response = self.client.post(
+            "{}/api/operations/{}/cmd".format(self.url, self.operation_id),
+            json={"command": command},
+            headers=self.authorized_headers
+        ).json()
+
+        if response["ack"] == False:
+            raise Exception('send_cmd failed.\n" + "command "{}"'.format(command))
+
+    def _send_utl_cmd(self, unixtime: float, command: dict) -> None:
+        command["execType"] = "UTL"
+        command["execTime"] = unixtime
         response = self.client.post(
             "{}/api/operations/{}/cmd".format(self.url, self.operation_id),
             json={"command": command},

--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -47,6 +47,20 @@ def send_bl_cmd_and_confirm(
     return _send_cmd_and_confirm(ope, func_send_cmd, cmd_code, cmd_args, tlm_code_hk)
 
 
+# TODO: HK で confirm する過程を追加する
+def send_tl_cmd(
+    ope: Operation, ti: int, cmd_code: int, cmd_args: tuple
+) -> str:
+    ope.send_tl_cmd(ti, cmd_code, cmd_args)
+
+
+# TODO: HK で confirm する過程を追加する
+def send_utl_cmd(
+    ope: Operation, unixtime: float, cmd_code: int, cmd_args: tuple
+) -> str:
+    ope.send_utl_cmd(unixtime, cmd_code, cmd_args)
+
+
 def _send_cmd_and_confirm(
     ope: Operation,
     func_send_cmd: Callable[[int, tuple], None],


### PR DESCRIPTION
## 概要
tl_cmdとutl_cmdも打てるようにした

## Issue
- https://github.com/ut-issl/c2a-core/issues/175

## 詳細
send_tl_cmd と send_utl_cmd 関数を追加した。HK を使って confirm する過程は省略しているので、今後実装する必要がある。

## 検証結果
wings と SILS で正しく動作することを確認した

## 影響範囲
特になし

## 補足