### PR TITLE
pip install -e . でエラーが出る問題を解消

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import setuptools
 setuptools.setup(
     name="isslwings",
     author="ISSL development team",
-    desctiption="",
+    description="",
+    packages=['isslwings'],
     install_requires=["httpx[http2]", "pytest"],
 )

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,6 @@ setuptools.setup(
     name="isslwings",
     author="ISSL development team",
     description="",
-    packages=['isslwings'],
+    packages=["isslwings"],
     install_requires=["httpx[http2]", "pytest"],
 )


### PR DESCRIPTION
## 概要
pip install -e . でエラーが出る問題を解消

## Issue
N/A

## 詳細
> error: Multiple top-level packages discovered in a flat-layout: ['samples', 'isslwings'].

`setup.py` でpackagesを明示したら解決した