### PR TITLE
WIP：sleepを削ってpytest実行時間を短くする

### DIFF
--- a/isslwings/operation.py
+++ b/isslwings/operation.py
@@ -200,8 +200,6 @@ class Operation:
         # テレメトリごとに更新時刻は保存されているが、とりあえず先頭を抽出
         received_time = telemetries[0]["telemetryValue"]["time"]
 
-        time.sleep(0.2)
-
         return telemetry_data, received_time
 
     def send_rt_cmd(self, cmd_code: int, cmd_params_value: tuple, component: str = "") -> None:


### PR DESCRIPTION
## 概要
sleepを削ってpytest実行時間を短くする

## Issue
N/A

## 詳細
core_sample で全てのpytestを回すのに，ざっくり25分→17分くらいまで縮まった。

## 検証結果
user側で pytest が通るかはこれから検証する

## 注意
- 関連する Projects が存在する場合，それの紐付けを行うこと
- Assignees を設定すること
- 可能ならば Reviewers を設定すること
- 可能ならば `priority` ラベルを付けること
