### PR TITLE
不要なsleepを削ってpytest実行時間を短くする

### DIFF
--- a/isslwings/operation.py
+++ b/isslwings/operation.py
@@ -200,8 +200,6 @@ class Operation:
         # テレメトリごとに更新時刻は保存されているが、とりあえず先頭を抽出
         received_time = telemetries[0]["telemetryValue"]["time"]
 
-        time.sleep(0.2)
-
         return telemetry_data, received_time
 
     def send_rt_cmd(self, cmd_code: int, cmd_params_value: tuple, component: str = "") -> None:


### PR DESCRIPTION
## 概要
不要なsleepを削ってpytest実行時間を短くする

## Issue
- N/A

## 詳細
`_send_cmd_and_confirm`などのfor文の中に sleep(0.2) があるので，今回削除したsleepは不要。

## 検証結果
どちらも既存のpytestは全て通り，実行時間も短縮された。
- minimum_user：25分→17分
- user：47分→37分

## 影響範囲
他でpytestを使っているuser部があれば検証必要か。

## 補足
何かあれば
