### PR TITLE
C2A Core 側の修正に伴う，デフォルト Tlm 名の修正

### DIFF
--- a/isslwings/operation.py
+++ b/isslwings/operation.py
@@ -16,9 +16,9 @@ default_obc_info = {
     "name": "MOBC",
     "hk_tlm_info": {
         "tlm_name": "HK",
-        "cmd_counter": "OBC_GS_CMD_COUNTER",
-        "cmd_last_exec_id": "OBC_GS_CMD_LAST_EXEC_ID",
-        "cmd_last_exec_sts": "OBC_GS_CMD_LAST_EXEC_STS",
+        "cmd_counter": "OBC.GS_CMD.COUNTER",
+        "cmd_last_exec_id": "OBC.GS_CMD.LAST_EXEC.ID",
+        "cmd_last_exec_sts": "OBC.GS_CMD.LAST_EXEC.EXEC_STS",
     },
 }
 


### PR DESCRIPTION
## 概要
C2A Core 側の修正に伴う，デフォルト Tlm 名の修正

## Issue
- https://github.com/ut-issl/c2a-core/pull/426 による対応

## 詳細
see diff

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/426 でテストする

## 影響範囲
デフォルト値を使ってるテストはすべて通らなくなる．

## その他
- [ ] 非互換なのでreleaseを打つ
  - こちらのツール自体は後方互換があるので， v1.2.3 とかかな．