### PR TITLE
Cmd_TG_FORWARD_TLM 対応

### DIFF
--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -20,6 +20,22 @@ def generate_and_receive_tlm(ope: Operation, cmd_code_generate_tlm: int, tlm_cod
     raise Exception("No response to GENERATE_TLM.")
 
 
+def forward_and_receive_tlm(ope: Operation, cmd_code_tg_forward_tlm: int, apid: int, tlm_code: int) -> dict:
+    _, received_time_prev = ope.get_latest_tlm(tlm_code)
+    # FIXME: get_latest_tlm 側の APID 対応
+
+    ope.send_rt_cmd(cmd_code_tg_forward_tlm, (apid, tlm_code, 2, 0, 1))
+
+    for _ in range(50):
+        time.sleep(0.2)
+
+        tlm, received_time_after = ope.get_latest_tlm(tlm_code)
+        if received_time_prev != received_time_after:
+            return tlm
+
+    raise Exception("No response to TG_FORWARD_TLM.")
+
+
 # FIXME: MOBC経由からの2nd OBCへのコマンドは，GS counterで confirm できないので，一旦対応しない．別関数つくる？
 def send_rt_cmd_and_confirm(
     ope: Operation, cmd_code: int, cmd_args: tuple, tlm_code_hk: int

--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -20,7 +20,9 @@ def generate_and_receive_tlm(ope: Operation, cmd_code_generate_tlm: int, tlm_cod
     raise Exception("No response to GENERATE_TLM.")
 
 
-def forward_and_receive_tlm(ope: Operation, cmd_code_tg_forward_tlm: int, apid: int, tlm_code: int) -> dict:
+def forward_and_receive_tlm(
+    ope: Operation, cmd_code_tg_forward_tlm: int, apid: int, tlm_code: int
+) -> dict:
     _, received_time_prev = ope.get_latest_tlm(tlm_code)
     # FIXME: get_latest_tlm 側の APID 対応
 


### PR DESCRIPTION
## 概要
Cmd_TG_FORWARD_TLM 対応

## Issue
- https://github.com/ut-issl/c2a-core/issues/537
- https://github.com/ut-issl/c2a-core/issues/539
- https://github.com/ut-issl/c2a-core/issues/540

## 詳細
- これに伴い，MOBC と 2nd OBC の tlm id の重複は許可される

以下とともにマージする

- https://github.com/ut-issl/c2a-core/pull/544
- https://github.com/ut-issl/c2a-tlm-cmd-code-generator/pull/36

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/544 で検証

## 影響範囲
- [ ]  非互換なのでリリースを打つ

## その他
- https://github.com/ut-issl/python-wings-interface/blob/dc7cb74f6a808f89489464e7600af7ec4f73cd9d/isslwings/util.py#L23-L27 の部分を直す必要がある（WINGS API 対応後）
  - https://github.com/ut-issl/python-wings-interface/issues/33 