### PR TITLE
GENERATE_TLM の依存を排除し，TG_GENERATE_MS_TLM を用いるようにする

### DIFF
--- a/example/sample_test_initial_tl.py
+++ b/example/sample_test_initial_tl.py
@@ -22,7 +22,7 @@ def test_initial_tl():
     assert ret == "SUC"
 
     tlm_BL = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_BL
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_BL
     )
     assert tlm_BL["BL.CMD0_ID"] == c2a_enum.Cmd_CODE_BCT_ROTATE_BLOCK
     assert tlm_BL["BL.CMD0_TI"] == 0
@@ -39,7 +39,7 @@ def test_add_bc():
     )
     assert ret == "SUC"
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.OBC_BCT_BLK_PTR"] == 300
     assert tlm_HK["HK.OBC_BCT_CMD_PTR"] == 0
@@ -52,7 +52,7 @@ def test_add_bc():
         c2a_enum.Tlm_CODE_HK,
     )
     tlm_HK = wings.util.generate_and_receive_tlm(
-        ope, c2a_enum.Cmd_CODE_GENERATE_TLM, c2a_enum.Tlm_CODE_HK
+        ope, c2a_enum.Cmd_CODE_TG_GENERATE_MS_TLM, c2a_enum.Tlm_CODE_HK
     )
     assert tlm_HK["HK.OBC_BCT_BLK_PTR"] == 300
     assert tlm_HK["HK.OBC_BCT_CMD_PTR"] == 1

--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -5,10 +5,10 @@ from typing import Callable
 from .operation import Operation
 
 
-def generate_and_receive_tlm(ope: Operation, cmd_code_generate_tlm: int, tlm_code: int) -> dict:
+def generate_and_receive_tlm(ope: Operation, cmd_code_tg_generate_ms_tlm: int, tlm_code: int) -> dict:
     _, received_time_prev = ope.get_latest_tlm(tlm_code)
 
-    ope.send_rt_cmd(cmd_code_generate_tlm, (0x40, tlm_code, 1))
+    ope.send_rt_cmd(cmd_code_tg_generate_ms_tlm, (tlm_code,))
 
     for _ in range(50):
         time.sleep(0.2)

--- a/isslwings/util.py
+++ b/isslwings/util.py
@@ -5,7 +5,9 @@ from typing import Callable
 from .operation import Operation
 
 
-def generate_and_receive_tlm(ope: Operation, cmd_code_tg_generate_ms_tlm: int, tlm_code: int) -> dict:
+def generate_and_receive_tlm(
+    ope: Operation, cmd_code_tg_generate_ms_tlm: int, tlm_code: int
+) -> dict:
     _, received_time_prev = ope.get_latest_tlm(tlm_code)
 
     ope.send_rt_cmd(cmd_code_tg_generate_ms_tlm, (tlm_code,))


### PR DESCRIPTION
## 概要
GENERATE_TLM の依存を排除し，TG_GENERATE_MS_TLM を用いるようにする

## Issue
- https://github.com/ut-issl/c2a-core/issues/543

## 詳細
GENERATE_TLM が deprecated になったことの対応．

以下とともにマージする

- https://github.com/ut-issl/c2a-core/pull/588

## 検証結果
- https://github.com/ut-issl/c2a-core/pull/588 で検証


## 補足
- [x] 非互換なのでリリースを打つ
